### PR TITLE
bug fix

### DIFF
--- a/ios/Classes/FlutterCallKitPlugin.h
+++ b/ios/Classes/FlutterCallKitPlugin.h
@@ -13,5 +13,6 @@ API_AVAILABLE(ios(10.0))
                    handleType:(NSString *_Nonnull)handleType
                      hasVideo:(BOOL)hasVideo
           localizedCallerName:(NSString * _Nullable)localizedCallerName
-                  fromPushKit:(BOOL)fromPushKit;
+                  fromPushKit:(BOOL)fromPushKit
+                   completion:(void (^)(void))completion;
 @end


### PR DESCRIPTION
Some problems found in the actual application process
- When pushit arrives, it needs to report the call to callkit immediately, and the complete function can be called when the report is completed
- All callkit related processing should be executed in the main thread, otherwise it will cause the problem that the call cannot be reported correctly in some cases and the app is terminated by the system.
- Callkit call display event function, due to the failure of parsing the parameter fromPushKit in flutter, this event cannot be reached correctly in flutter